### PR TITLE
Update library to Craiyon v2 and keep backward compatibility for the v1 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,18 +51,6 @@ Or just manually clone the repository and build the wheel
 **Generate and save the images**
 
 ```py
-
-from craiyon import Craiyon
-
-generator = Craiyon()
-
-## Usage / Examples
-
-### 
-
-**Generate and save the images**
-
-```py
 from craiyon import Craiyon
 
 generator = Craiyon() # Instantiates the api wrapper

--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ The easiest way to install craiyon.py is using pip
 Or just manually clone the repository and build the wheel
 
 
-## Specify custom tokens/model versions
+## Usage / Examples
+
+### 
+
+**Generate and save the images**
 
 ```py
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ for i in images:
 ```
 ![image](https://user-images.githubusercontent.com/55452780/181877028-740bee12-432d-4019-b74e-a17f53b79987.png)
 
-## Just get the Direct Image URLs
+**Just get the Direct Image URLs**
 ```py
 from craiyon import Craiyon
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Information about each argument:
 
 ### api_token
 * If you bought a paid subscription to Craiyon.com, you would know that the watermark is removed. If you wish to have the watermark removed from the generated images in your application as well, you can specify a token here. 
-* To find your token: Open Google Chrome, go to craiyon.com (make sure you're logged in), Press F12, go to the Network tab, make sure the record button is looks like a red circle at the top-left, and start generating a prompt. Two "draw" items should appear on the left, under "name". One of them will have a "Payload" tab next to "Headers" and "Preview", as well as above "General". Click it, and your token is listed there.
+* To find your token: Open Google Chrome, go to craiyon.com (make sure you're logged in), Press F12, go to the Network tab, make sure the record button looks like a red circle at the top-left. Put your prompt in the text box and press the orange "Draw" button. Two "draw" items should appear on the left, under "name". One of them will have a "Payload" tab next to "Headers" and "Preview", as well as above "General". Click it, and your token is listed there.
 
 ### model_version
 * Since Craiyon is still training their V2 model, it is improving every day. We recommend putting your own model version here to get the newest and best model they have at the moment.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ async def genimage(ctx, *, prompt: str):
     for index, image in enumerate(b64_list): # Loop through b64_list, keeping track of the index
         img_bytes = BytesIO(base64.b64decode(image)) # Decode the image and store it as a bytes object
         image = discord.File(img_bytes)
-        image.filename = f"result{index}.jpg"
+        image.filename = f"result{index}.webp"
         images1.append(image) # Add the image to the images1 list
         
     await ctx.reply(files=images1) # Reply to the user with all 9 images in 1 message

--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ for i in images:
 ```
 ![image](https://user-images.githubusercontent.com/55452780/181877028-740bee12-432d-4019-b74e-a17f53b79987.png)
 
+## Just get the Direct Image URLs
+```py
+from craiyon import Craiyon
+
+generator = Craiyon() # Instantiates the api wrapper
+result = generator.generate("Photorealistic image of shrek eating earth")
+
+print(result.images) # Prints a list of the Direct Image URLs hosted on https://img.craiyon.com
+
+# Loops through the list and prints each image URL one by one
+for url in result.images:
+    print(url)
+```
+
 ## Async Usage / Examples
 
 ###

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ The easiest way to install craiyon.py is using pip
 Or just manually clone the repository and build the wheel
 
 
+## Specify custom tokens/model versions
+
+```py
+
+from craiyon import Craiyon
+
+generator = Craiyon()
+
 ## Usage / Examples
 
 ### 
@@ -62,16 +70,16 @@ result.save_images() # Saves the generated images to 'current working directory/
 **Use the images in your code without saving**
 
 ```py
-from craiyon import Craiyon
+from craiyon import Craiyon, craiyon_utils
 from PIL import Image # pip install pillow
 from io import BytesIO
 import base64
 
 generator = Craiyon() # Instantiates the api wrapper
 result = generator.generate("Professional photo of Obama flashing a flag with his last name") # Generates 9 images by default and you cannot change that
-images = result.images # A list containing image data as base64 encoded strings
+images = craiyon_utils.encode_base64(result.images)
 for i in images:
-    image = Image.open(BytesIO(base64.decodebytes(i.encode("utf-8"))))
+    image = Image.open(BytesIO(base64.decodebytes(i)))
     # Use the PIL's Image object as per your needs
 ```
 ![image](https://user-images.githubusercontent.com/55452780/181877028-740bee12-432d-4019-b74e-a17f53b79987.png)
@@ -135,6 +143,34 @@ async def genimage(ctx, *, prompt: str):
 
 bot.run("your_token_here")
 ```
+
+## Specify custom tokens/model versions
+
+```py
+
+from craiyon import Craiyon
+
+generator = Craiyon()
+
+result = generator.generate("Teddy bear riding a skateboard", api_token="token-here", model_version="35s5hfwn9n78gb06") # api_token and model_version are not required, but recommended
+
+```
+
+Information about each argument:
+
+### api_token
+* If you bought a paid subscription to Craiyon.com, you would know that the watermark is removed. If you wish to have the watermark removed from the generated images in your application as well, you can specify a token here. 
+* To find your token: Open Google Chrome, go to craiyon.com (make sure you're logged in), Press F12, go to the Network tab, make sure the record button is looks like a red circle at the top-left, and start generating a prompt. Two "draw" items should appear on the left, under "name". One of them will have a "Payload" tab next to "Headers" and "Preview", as well as above "General". Click it, and your token is listed there.
+
+### model_version
+* Since Craiyon is still training their V2 model, it is improving every day. We recommend putting your own model version here to get the newest and best model they have at the moment.
+* To get the model version, follow the steps for the api_token listed above, except copy the "version" instead of the "token". Then, just pass it in as an argument for the generate() function as a string and you're ready!
+* While this is recommended, it is not required. If you do not pass a custom model version, this value will automatically default to "35s5hfwn9n78gb06", which is Craiyon's newest model as of March 10, 2023.
+
+## Backwards Compatibility
+This library is fully backwards-compatible with older versions.
+
+If you were previously using this library before we added support for Craiyon's V2 model and you wish to continue using the old V1 model, simply change the name of the class `Craiyon` to `CraiyonV1`! Otherwise, you can update your application to the V2 model by reading the code samples above.
 
 
 ## Todo

--- a/craiyon/__init__.py
+++ b/craiyon/__init__.py
@@ -1,4 +1,4 @@
-from craiyon.craiyon import Craiyon
+from craiyon.craiyon import Craiyon, CraiyonV1
 
 __author__ = "FireHead90544"
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/craiyon/craiyon.py
+++ b/craiyon/craiyon.py
@@ -1,26 +1,140 @@
 from __future__ import annotations
 import aiohttp
 import requests
-from craiyon.templates import GeneratedImages
+from craiyon.templates import GeneratedImagesV1, GeneratedImagesV2
 
+
+# V2 version of Craiyon API
 class Craiyon:
     '''
-    Instantiates a Craiyon session, allows user to generate images from text tokens.
-    The model takes some time to generate the images (roughly around 2 minutes).
+    Instantiates a Craiyon session, allows user to generate images from text prompts.
+    The model takes some time to generate the images (roughly around 1 minute).
     So be patient, and don't abuse the api, as I am not the one hosting the model, craiyon itself is.
     '''
     def __init__(self) -> None:
-        self.BASE_URL = "https://backend.craiyon.com"
+        self.BASE_URL = "https://api.craiyon.com"
+        self.DRAW_API_ENDPOINT = "/draw"
+        self.default_model_version = "35s5hfwn9n78gb06"
     
-    def generate(self, tokens: str) -> GeneratedImages:
+    # Generate images with V2
+    def generate(self, prompt: str, api_token: str = None, model_version: str = None) -> GeneratedImagesV2:
+        
+        """
+        Generates 9 images using the V2 model of Craiyon.
+        
+        Arguments:
+        - (Required) | Prompt: The text prompt that will be used to generate the images
+        
+        - (Not required) | api_token: Useful if you're paying for a subscription on Craiyon's website and want to remove the watermark from the generated images
+        
+        - (Not required) | model_version: Since Craiyon is constantly updating their V2 model seemingly everyday, you can specify a newer model here.
+        Defaults to \"35s5hfwn9n78gb06\" (March 10th Model) if nothing is specified here
+        
+        Returns:
+        - Returns a list of direct image links to `.webp` images, from https://img.craiyon.com
+        """
+        
+        imagelist = []
+        
+        if model_version == None:
+            model_version = self.default_model_version
+            
+        url = self.BASE_URL + self.DRAW_API_ENDPOINT
         session = requests.Session()
-        url = self.BASE_URL + "/generate"
-        resp = session.post(url, json={'prompt': tokens})
-        return GeneratedImages(resp.json()['images'])
-
-    async def async_generate(self, tokens: str) -> GeneratedImages:
-        url = self.BASE_URL + "/generate"
+        resp = session.post(url, json={'prompt': prompt, "token": api_token, "version": model_version})
+        
+        resp = resp.json()
+        
+        urls_no_domain = resp['images']
+        
+        # Add protocol, domain and subdomain (https://img.craiyon.com) to each item as those aren't included in the response by default
+        for item in urls_no_domain:
+            imagelist.append(f"https://img.craiyon.com/{item}")
+        
+        return GeneratedImagesV2(imagelist)
+    
+    # Generate images with V2, asynchronously
+    async def async_generate(self, prompt: str, api_token: str = None, model_version: str = None) -> GeneratedImagesV2:
+        
+        """
+        Generates 9 images asynchronously using the V2 model of Craiyon.
+        
+        Arguments:
+        - (Required) | Prompt: The text prompt that will be used to generate the images
+        
+        - (Not required) | api_token: Useful if you're paying for a subscription on Craiyon's website and want to remove the watermark from the generated images
+        
+        - (Not required) | model_version: Since Craiyon is constantly updating their V2 model seemingly everyday, you can specify a newer model here.
+        Defaults to \"35s5hfwn9n78gb06\" (March 10th Model) if nothing is specified here
+        
+        Returns:
+        - Returns a list of direct image links to `.webp` images, from https://img.craiyon.com
+        """
+        
+        imagelist = []
+        
+        if model_version == None:
+            model_version = self.default_model_version
+        
+        url = self.BASE_URL + self.DRAW_API_ENDPOINT
         async with aiohttp.ClientSession() as sess:
-            async with sess.post(url, json={"prompt": tokens}) as resp:
+            async with sess.post(url, json={'prompt': prompt, "token": api_token, "version": model_version}) as resp:
+                
+                urls_no_domain = await resp.json()
+                urls_no_domain = urls_no_domain['images']
+                
+                # Add protocol, domain and subdomain (https://img.craiyon.com) to each item as those aren't included in the response by default
+                for item in urls_no_domain:
+                    imagelist.append(f"https://img.craiyon.com/{item}")
+        
+                return GeneratedImagesV2(imagelist)
+    
+# V1 version of Craiyon API, for backwards compatibility
+class CraiyonV1:
+    '''
+    **NOTICE**: This is the V1 version of Craiyon's model. To use the updated V2 model, use the normal `Craiyon` class instead.
+    
+    Instantiates a Craiyon session, allows user to generate images from text prompts.
+    The model takes some time to generate the images (roughly around 1 minute).
+    So be patient, and don't abuse the api, as I am not the one hosting the model, craiyon itself is.
+    '''
+    
+    
+    def __init__(self) -> None:
+        self.BASE_URL = "https://backend.craiyon.com"
+        self.DRAW_API_ENDPOINT = "/generate"
+    
+    def generate(self, prompt: str) -> GeneratedImagesV1:
+        
+        """
+        Generates 9 images using the V1 model of Craiyon.
+        
+        Arguments:
+        - (Required) | Prompt: The text prompt that will be used to generate the images
+        
+        Returns:
+        - Returns a list of 9 Base64 bytestrings (.jpg)
+        """
+        
+        session = requests.Session()
+        url = self.BASE_URL + self.DRAW_API_ENDPOINT
+        resp = session.post(url, json={'prompt': prompt})
+        return GeneratedImagesV1(resp.json()['images'])
+
+    async def async_generate(self, prompt: str) -> GeneratedImagesV1:
+        
+        """
+        Generates 9 images asynchronously using the V1 model of Craiyon.
+        
+        Arguments:
+        - (Required) | Prompt: The text prompt that will be used to generate the images
+        
+        Returns:
+        - Returns a list of 9 Base64 bytestrings (.jpg)
+        """
+        
+        url = self.BASE_URL + self.DRAW_API_ENDPOINT
+        async with aiohttp.ClientSession() as sess:
+            async with sess.post(url, json={"prompt": prompt}) as resp:
                 resp = await resp.json()
-                return GeneratedImages(resp['images'])
+                return GeneratedImagesV1(resp['images'])

--- a/craiyon/craiyon_utils.py
+++ b/craiyon/craiyon_utils.py
@@ -1,0 +1,46 @@
+import requests
+import aiohttp
+import base64
+
+
+# Encode a list of Direct Image URLs to B64 Bytestrings
+def encode_base64(image_list: list):
+    '''
+    Takes a list of direct image URLs from https://img.craiyon.com, downloads each image, and encodes them into a bytes object using Base64 encoding
+    
+    Returns:
+    - Returns a list of bytestring objects encoded with Base64
+    '''
+    
+    b64_object_list = []
+    
+    for url in image_list:
+        response = requests.get(url=url)
+        if response.status_code == 200:
+            # Convert image to bytes
+            bytestring = base64.b64encode(response.content)
+            b64_object_list.append(bytestring)
+            
+    return b64_object_list
+
+# Asynchronously encode a list of Direct Image URLs to B64 Bytestrings        
+async def async_encode_base64(image_list: list):
+    '''
+    Asynchronously takes a list of direct image URLs from https://img.craiyon.com, downloads each image, and encodes them into a bytes object using Base64 encoding
+    
+    Returns:
+    - Returns a list of bytestring objects encoded with Base64
+    '''
+    
+    b64_object_list = []
+    
+    for url in image_list:
+        async with aiohttp.ClientSession() as sess:
+            async with sess.get(url=url) as resp:
+                if resp.status == 200:
+                    # Convert image to bytes
+                    resp = await resp.read()
+                    bytestring = base64.b64encode(resp)
+                    b64_object_list.append(bytestring)
+                    
+    return b64_object_list

--- a/craiyon/templates.py
+++ b/craiyon/templates.py
@@ -2,56 +2,13 @@ import base64
 from pathlib import Path
 import aiofiles
 from aiopath import AsyncPath
-import requests
-import aiohttp
+from craiyon.craiyon_utils import encode_base64, async_encode_base64
 
 
 # Handles V2 version of Craiyon API
 class GeneratedImagesV2:
     def __init__(self, imagelist: list):
         self.images = imagelist
-        
-    # Encode a list of Direct Image URLs to B64 Bytestrings
-    def encode_base64(self, image_list: list):
-        '''
-        Takes a list of direct image URLs from https://img.craiyon.com, downloads each image, and encodes them into a bytes object using Base64 encoding
-        
-        Returns:
-        - Returns a list of bytestring objects encoded with Base64
-        '''
-        
-        b64_object_list = []
-        
-        for url in image_list:
-            response = requests.get(url=url)
-            if response.status_code == 200:
-                # Convert image to bytes
-                bytestring = base64.b64encode(response.content)
-                b64_object_list.append(bytestring)
-                
-        return b64_object_list
-    
-    # Asynchronously encode a list of Direct Image URLs to B64 Bytestrings        
-    async def async_encode_base64(self, image_list: list):
-        '''
-        Asynchronously takes a list of direct image URLs from https://img.craiyon.com, downloads each image, and encodes them into a bytes object using Base64 encoding
-        
-        Returns:
-        - Returns a list of bytestring objects encoded with Base64
-        '''
-        
-        b64_object_list = []
-        
-        for url in image_list:
-            async with aiohttp.ClientSession() as sess:
-                async with sess.get(url=url) as resp:
-                    if resp.status == 200:
-                        # Convert image to bytes
-                        resp = await resp.read()
-                        bytestring = base64.b64encode(resp)
-                        b64_object_list.append(bytestring)
-                        
-        return b64_object_list
             
     
     # Save Images  
@@ -64,7 +21,7 @@ class GeneratedImagesV2:
         '''
         
         # Get list of bytestring objects
-        image_list = GeneratedImagesV2.encode_base64(self, self.images)
+        image_list = encode_base64(self.images)
         # Make new directory
         path = (Path.cwd() / 'generated') if not path else Path(path)
         path.mkdir(parents=True, exist_ok=True)
@@ -83,7 +40,7 @@ class GeneratedImagesV2:
         '''
         
         # Get list of bytestring objects
-        image_list = await GeneratedImagesV2.async_encode_base64(self, self.images)
+        image_list = await async_encode_base64(self.images)
         # Make new directory
         path = (AsyncPath.cwd() / 'generated') if not path else AsyncPath(path)
         await path.mkdir(parents=True, exist_ok=True)

--- a/craiyon/templates.py
+++ b/craiyon/templates.py
@@ -2,8 +2,99 @@ import base64
 from pathlib import Path
 import aiofiles
 from aiopath import AsyncPath
+import requests
+import aiohttp
 
-class GeneratedImages:
+
+# Handles V2 version of Craiyon API
+class GeneratedImagesV2:
+    def __init__(self, imagelist: list):
+        self.images = imagelist
+        
+    # Encode a list of Direct Image URLs to B64 Bytestrings
+    def encode_base64(self, image_list: list):
+        '''
+        Takes a list of direct image URLs from https://img.craiyon.com, downloads each image, and encodes them into a bytes object using Base64 encoding
+        
+        Returns:
+        - Returns a list of bytestring objects encoded with Base64
+        '''
+        
+        b64_object_list = []
+        
+        for url in image_list:
+            response = requests.get(url=url)
+            if response.status_code == 200:
+                # Convert image to bytes
+                bytestring = base64.b64encode(response.content)
+                b64_object_list.append(bytestring)
+                
+        return b64_object_list
+    
+    # Asynchronously encode a list of Direct Image URLs to B64 Bytestrings        
+    async def async_encode_base64(self, image_list: list):
+        '''
+        Asynchronously takes a list of direct image URLs from https://img.craiyon.com, downloads each image, and encodes them into a bytes object using Base64 encoding
+        
+        Returns:
+        - Returns a list of bytestring objects encoded with Base64
+        '''
+        
+        b64_object_list = []
+        
+        for url in image_list:
+            async with aiohttp.ClientSession() as sess:
+                async with sess.get(url=url) as resp:
+                    if resp.status == 200:
+                        # Convert image to bytes
+                        resp = await resp.read()
+                        bytestring = base64.b64encode(resp)
+                        b64_object_list.append(bytestring)
+                        
+        return b64_object_list
+            
+    
+    # Save Images  
+    def save_images(self, path: str=None):
+        '''
+        Saves the generated images to the given path.
+        Defaults to cwd/generated
+        
+        Filetype saved: `.webp`
+        '''
+        
+        # Get list of bytestring objects
+        image_list = GeneratedImagesV2.encode_base64(self, self.images)
+        # Make new directory
+        path = (Path.cwd() / 'generated') if not path else Path(path)
+        path.mkdir(parents=True, exist_ok=True)
+        # Save each image to specified path
+        for i in enumerate(image_list):
+            with open(path / f'image-{i[0]+1}.webp', 'wb') as f:
+                f.write(base64.decodebytes(i[1])) # Save file to disk
+    
+    # Async Save Images
+    async def async_save_images(self, path: str=None):
+        '''
+        Asynchronously saves the generated images to the given path.
+        Defaults to cwd/generated.
+        
+        Filetype saved: `.webp`
+        '''
+        
+        # Get list of bytestring objects
+        image_list = await GeneratedImagesV2.async_encode_base64(self, self.images)
+        # Make new directory
+        path = (AsyncPath.cwd() / 'generated') if not path else AsyncPath(path)
+        await path.mkdir(parents=True, exist_ok=True)
+        # Save each image to specified path
+        for i in enumerate(image_list):
+            async with aiofiles.open(path / f'image-{i[0]+1}.webp', 'wb') as f:
+                await f.write(base64.decodebytes(i[1])) # Save file to disk
+
+
+# Handles V1 version of Craiyon API
+class GeneratedImagesV1:
     def __init__(self, images: dict):
         self.images = images
         
@@ -11,6 +102,8 @@ class GeneratedImages:
         '''
         Saves the generated images to the given path.
         Defaults to cwd/generated
+        
+        Filetype saved: `.jpg`
         '''
         path = (Path.cwd() / 'generated') if not path else Path(path)
         path.mkdir(parents=True, exist_ok=True)
@@ -22,6 +115,8 @@ class GeneratedImages:
         '''
         Saves the generated images to the given path.
         Defaults to cwd/generated.
+        
+        Filetype saved: `.jpg`
         '''
         path = (AsyncPath.cwd() / 'generated') if not path else AsyncPath(path)
         await path.mkdir(parents=True, exist_ok=True)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     readme = fh.read()
 
 setup(name='craiyon.py',
-      version='0.2.0',
+      version='0.3.0',
       description='API Wrapper for craiyon.com (DAL-E-MINI). Generate awesome images from text tokens.',
       long_description=readme,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
Craiyon has a new model and a new API to go with it, which produces much better images.

This pull request adds support for the v2 model and the new API, while keeping backward compatibility for the old model. Current users of this library only have to change the name of the `Craiyon` class in their code to `CraiyonV1` if they wish to keep using it. That is the only breaking change for those who wish to stay on V1.

There are a few minor breaking changes for those who wish to upgrade to the v2 model. Please read the new README.md for more info.
The generated images in the V2 model are also now returned as `.webp` files instead of `.jpg`, so any of you who wish to update your applications to utilize the new model should adapt to this new change too.

I made a new file in the craiyon directory called "craiyon_utils.py"  which contains functions to download the images off of Craiyon's servers, as the new API returns images as Direct Image URLs instead of just sending them as B64 strings directly.

Should I rename the functions to something else, such as download_images() or are they fine right now?

Also, sorry for all those commits again, I just can't read lol

